### PR TITLE
There was a bug where player's were now OP

### DIFF
--- a/plugin/src/main/java/be/nokorbis/spigot/commandsigns/controller/executions/CommandsRunner.java
+++ b/plugin/src/main/java/be/nokorbis/spigot/commandsigns/controller/executions/CommandsRunner.java
@@ -89,8 +89,15 @@ public class CommandsRunner implements Callable<CommandsRunner.Result> {
 		String cmd = command.substring(1);
 		if (!this.player.isOp()) {
 			this.player.setOp(true);
-			interpretNormalCommand(cmd);
-			this.player.setOp(false);
+			
+			try {
+				interpretNormalCommand(cmd);			
+			} catch(Exception ex) {
+				ex.printStackTrace();
+			} finally {
+				// IF ANYTHING GOES WRONG WE WANT THE PLAYER TO STOP BEING AN OP.
+				this.player.setOp(false);				
+			}
 		}
 		else {
 			interpretNormalCommand(cmd);


### PR DESCRIPTION
If something went wrong at the moment of executing the command, the player would never become again a non-op. With this try-catch surrounding that is now fixed.